### PR TITLE
Refactor CSS with brutalist palette variables

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -1,16 +1,25 @@
+/* Brutalist color scheme */
+:root {
+  --color-dark-gray: #4A4A4A;
+  --color-light-gray: #D9D9D9;
+  --color-accent: #FF4C00;
+  --color-black: #1C1C1C;
+  --color-white: #FFFFFF;
+}
+
 body {
   font-family: "Courier New", monospace;
   margin: 0;
   line-height: 1.4;
-  background: #D9D9D9;
-  color: #1C1C1C;
+  background: var(--color-light-gray);
+  color: var(--color-black);
 }
 header {
-  background: #4A4A4A;
-  color: #FFFFFF;
+  background: var(--color-dark-gray);
+  color: var(--color-white);
   padding: 2rem 1rem;
   text-align: center;
-  border-bottom: 4px solid #FF4C00;
+  border-bottom: 4px solid var(--color-accent);
 }
 header h1 {
   margin: 0;
@@ -26,40 +35,40 @@ header p {
   height: 300px;
 }
 nav {
-  background: #FF4C00;
-  border-bottom: 4px solid #1C1C1C;
+  background: var(--color-accent);
+  border-bottom: 4px solid var(--color-black);
   text-align: center;
   padding: 0.75rem;
 }
 nav a {
-  color: #FFFFFF;
+  color: var(--color-white);
   margin: 0 1rem;
   text-decoration: none;
   font-weight: 700;
   padding: 0.25rem 0.5rem;
 }
 nav a:hover {
-  background: #FFFFFF;
-  color: #1C1C1C;
+  background: var(--color-white);
+  color: var(--color-black);
 }
 main {
   max-width: 900px;
   margin: 0 auto;
   padding: 1rem;
-  background: #FFFFFF;
-  border-left: 4px solid #1C1C1C;
-  border-right: 4px solid #1C1C1C;
+  background: var(--color-white);
+  border-left: 4px solid var(--color-black);
+  border-right: 4px solid var(--color-black);
 }
 section {
   margin-bottom: 3rem;
-  border-bottom: 2px dashed #FF4C00;
+  border-bottom: 2px dashed var(--color-accent);
   padding-bottom: 1rem;
 }
 h2 {
   font-size: 1.8rem;
   margin-top: 2rem;
   margin-bottom: 1rem;
-  color: #FF4C00;
+  color: var(--color-accent);
   font-weight: 700;
   text-transform: uppercase;
 }
@@ -70,29 +79,29 @@ table {
   width: 100%;
   border-collapse: collapse;
   margin-top: 1rem;
-  background: #FFFFFF;
+  background: var(--color-white);
 }
 table, th, td {
-  border: 2px solid #1C1C1C;
+  border: 2px solid var(--color-black);
 }
 th, td {
   padding: 0.75rem;
   text-align: left;
 }
 th {
-  background: #4A4A4A;
-  color: #FFFFFF;
+  background: var(--color-dark-gray);
+  color: var(--color-white);
 }
 
 .table-section {
-  background: #D9D9D9;
-  color: #1C1C1C;
+  background: var(--color-light-gray);
+  color: var(--color-black);
   font-weight: bold;
 }
 
 .template {
-  background: #FFFFFF;
-  border: 2px solid #1C1C1C;
+  background: var(--color-white);
+  border: 2px solid var(--color-black);
   padding: 1em;
   overflow-x: auto;
   font-size: 0.98em;
@@ -105,21 +114,21 @@ th {
 footer {
   text-align: center;
   padding: 2rem 1rem;
-  border-top: 4px solid #FF4C00;
+  border-top: 4px solid var(--color-accent);
   font-size: 0.875rem;
-  color: #1C1C1C;
+  color: var(--color-black);
 }
 
 .copy-btn {
   cursor: pointer;
-  background: #4A4A4A;
-  color: #FFFFFF;
-  border: 2px solid #1C1C1C;
+  background: var(--color-dark-gray);
+  color: var(--color-white);
+  border: 2px solid var(--color-black);
   padding: 0.4em 0.8em;
   font-size: 0.95em;
 }
 
 .copy-btn:hover {
-  background: #FF4C00;
-  color: #FFFFFF;
+  background: var(--color-accent);
+  color: var(--color-white);
 }


### PR DESCRIPTION
## Summary
- centralize brutalist colors using CSS variables
- apply variables throughout the stylesheet

## Testing
- `grep -n '#[0-9A-Fa-f]\{6\}' docs/style.css`

------
https://chatgpt.com/codex/tasks/task_e_6877b531d3988323959295f709d1d7ba